### PR TITLE
changes to customizationID/ProfileID

### DIFF
--- a/resources/ausdigital-syn/2.0/samples/Invoice/SampleInvoice-ConformantCreditNote.json
+++ b/resources/ausdigital-syn/2.0/samples/Invoice/SampleInvoice-ConformantCreditNote.json
@@ -1,8 +1,9 @@
 {
     "Invoice": {
+        "documentIdentifier": "digitalbusinesscouncil.com.au::urn:oasis:names:specification:ubl:schema:xsd:Invoice-2::Invoice##UBL-2.1",
         "ublVersionID": "2.1",
-        "customizationID": "urn:resources.digitalbusinesscouncil.com.au:dbc:invoicing:documents:core invoice:xsd::core invoice 1##urn:resources.digitalbusinesscouncil.com.au:dbc:einvoicing:process:einvoicing03:ver1.0",
-        "profileID": "urn:resources.digitalbusinesscouncil.com.au:dbc:einvoicing:ver1.0",
+        "customizationID": "digitalbusinesscouncil.com.au",
+        "profileID": "credit-note:v1.0",
         "id": "TOSL-108-A",
         "issueDate": "2016-07-01",
         "dueDate": "2016-08-01",

--- a/resources/ausdigital-syn/2.0/samples/Invoice/SampleInvoice-ConformantInvoice.json
+++ b/resources/ausdigital-syn/2.0/samples/Invoice/SampleInvoice-ConformantInvoice.json
@@ -1,8 +1,9 @@
 {
     "Invoice": {
+        "documentIdentifier": "digitalbusinesscouncil.com.au::urn:oasis:names:specification:ubl:schema:xsd:Invoice-2::Invoice##UBL-2.1",
         "ublVersionID": "2.1",
-        "customizationID": "urn:resources.digitalbusinesscouncil.com.au:dbc:invoicing:documents:core invoice:xsd::core invoice 1##urn:resources.digitalbusinesscouncil.com.au:dbc:einvoicing:process:einvoicing01:ver1.0",
-        "profileID": "urn:resources.digitalbusinesscouncil.com.au:dbc:einvoicing:ver1.0",
+        "customizationID": "digitalbusinesscouncil.com.au",
+        "profileID": "invoice:v1.0",
         "id": "TOSL-108-A",
         "issueDate": "2016-07-01",
         "dueDate": "2016-08-01",

--- a/resources/ausdigital-syn/2.0/samples/Invoice/SampleInvoice-InvalidCountryCode.json
+++ b/resources/ausdigital-syn/2.0/samples/Invoice/SampleInvoice-InvalidCountryCode.json
@@ -1,8 +1,9 @@
 {
     "Invoice": {
+        "documentIdentifier": "digitalbusinesscouncil.com.au::urn:oasis:names:specification:ubl:schema:xsd:Invoice-2::Invoice##UBL-2.1",
         "ublVersionID": "2.1",
-        "customizationID": "urn:resources.digitalbusinesscouncil.com.au:dbc:invoicing:documents:core invoice:xsd::core invoice 1##urn:resources.digitalbusinesscouncil.com.au:dbc:einvoicing:process:einvoicing01:ver1.0",
-        "profileID": "urn:resources.digitalbusinesscouncil.com.au:dbc:einvoicing:ver1.0",
+        "customizationID": "digitalbusinesscouncil.com.au",
+        "profileID": "invoice:v1.0",
         "id": "TOSL-108-A",
         "issueDate": "2016-07-01",
         "dueDate": "2016-08-01",

--- a/resources/ausdigital-syn/2.0/samples/Invoice/SampleInvoice-InvalidCurrency.json
+++ b/resources/ausdigital-syn/2.0/samples/Invoice/SampleInvoice-InvalidCurrency.json
@@ -1,8 +1,9 @@
 {
     "Invoice": {
+        "documentIdentifier": "digitalbusinesscouncil.com.au::urn:oasis:names:specification:ubl:schema:xsd:Invoice-2::Invoice##UBL-2.1",
         "ublVersionID": "2.1",
-        "customizationID": "urn:resources.digitalbusinesscouncil.com.au:dbc:invoicing:documents:core invoice:xsd::core invoice 1##urn:resources.digitalbusinesscouncil.com.au:dbc:einvoicing:process:einvoicing01:ver1.0",
-        "profileID": "urn:resources.digitalbusinesscouncil.com.au:dbc:einvoicing:ver1.0",
+        "customizationID": "digitalbusinesscouncil.com.au",
+        "profileID": "invoice:v1.0",
         "id": "TOSL-108-A",
         "issueDate": "2016-07-01",
         "dueDate": "2016-08-01",

--- a/resources/ausdigital-syn/2.0/samples/Invoice/SampleInvoice-Rule1-NotATaxInvoice.json
+++ b/resources/ausdigital-syn/2.0/samples/Invoice/SampleInvoice-Rule1-NotATaxInvoice.json
@@ -1,8 +1,9 @@
 {
     "Invoice": {
+        "documentIdentifier": "digitalbusinesscouncil.com.au::urn:oasis:names:specification:ubl:schema:xsd:Invoice-2::Invoice##UBL-2.1",
         "ublVersionID": "2.1",
-        "customizationID": "urn:resources.digitalbusinesscouncil.com.au:dbc:invoicing:documents:core invoice:xsd::core invoice 1##urn:resources.digitalbusinesscouncil.com.au:dbc:einvoicing:process:einvoicing01:ver1.0",
-        "profileID": "urn:resources.digitalbusinesscouncil.com.au:dbc:einvoicing:ver1.0",
+        "customizationID": "digitalbusinesscouncil.com.au",
+        "profileID": "invoice:v1.0",
         "id": "TOSL-108-A",
         "issueDate": "2016-07-01",
         "dueDate": "2016-08-01",

--- a/resources/ausdigital-syn/2.0/samples/Invoice/SampleInvoice-Rule13-NoInvoiceLineGST.json
+++ b/resources/ausdigital-syn/2.0/samples/Invoice/SampleInvoice-Rule13-NoInvoiceLineGST.json
@@ -1,8 +1,9 @@
 {
     "Invoice": {
+        "documentIdentifier": "digitalbusinesscouncil.com.au::urn:oasis:names:specification:ubl:schema:xsd:Invoice-2::Invoice##UBL-2.1",
         "ublVersionID": "2.1",
-        "customizationID": "urn:resources.digitalbusinesscouncil.com.au:dbc:invoicing:documents:core invoice:xsd::core invoice 1##urn:resources.digitalbusinesscouncil.com.au:dbc:einvoicing:process:einvoicing01:ver1.0",
-        "profileID": "urn:resources.digitalbusinesscouncil.com.au:dbc:einvoicing:ver1.0",
+        "customizationID": "digitalbusinesscouncil.com.au",
+        "profileID": "invoice:v1.0",
         "id": "TOSL-108-A",
         "issueDate": "2016-07-01",
         "dueDate": "2016-08-01",

--- a/resources/ausdigital-syn/2.0/samples/Invoice/SampleInvoice-Rule2-InvalidDocumentType.json
+++ b/resources/ausdigital-syn/2.0/samples/Invoice/SampleInvoice-Rule2-InvalidDocumentType.json
@@ -1,8 +1,9 @@
 {
     "Invoice": {
+        "documentIdentifier": "digitalbusinesscouncil.com.au::urn:oasis:names:specification:ubl:schema:xsd:Invoice-2::Invoice##UBL-2.1",
         "ublVersionID": "2.1",
-        "customizationID": "urn:resources.digitalbusinesscouncil.com.au:dbc:invoicing:documents:core invoice:xsd::core invoice 1##urn:resources.digitalbusinesscouncil.com.au:dbc:einvoicing:process:einvoicing01:ver1.0",
-        "profileID": "urn:resources.digitalbusinesscouncil.com.au:dbc:einvoicing:ver1.0",
+        "customizationID": "digitalbusinesscouncil.com.au",
+        "profileID": "invoice:v1.0",
         "id": "TOSL-108-A",
         "issueDate": "2016-07-01",
         "dueDate": "2016-08-01",

--- a/resources/ausdigital-syn/2.0/samples/Invoice/SampleInvoice-Rule21-RCTIwithoutBuyersIdentifier.json
+++ b/resources/ausdigital-syn/2.0/samples/Invoice/SampleInvoice-Rule21-RCTIwithoutBuyersIdentifier.json
@@ -1,8 +1,9 @@
 {
     "Invoice": {
+        "documentIdentifier": "digitalbusinesscouncil.com.au::urn:oasis:names:specification:ubl:schema:xsd:Invoice-2::Invoice##UBL-2.1",
         "ublVersionID": "2.1",
-        "customizationID": "urn:resources.digitalbusinesscouncil.com.au:dbc:invoicing:documents:core invoice:xsd::core invoice 1##urn:resources.digitalbusinesscouncil.com.au:dbc:einvoicing:process:einvoicing02:ver1.0",
-        "profileID": "urn:resources.digitalbusinesscouncil.com.au:dbc:einvoicing:ver1.0",
+        "customizationID": "digitalbusinesscouncil.com.au",
+        "profileID": "rcti:v1.0",
         "id": "TOSL-108-A",
         "issueDate": "2016-07-01",
         "dueDate": "2016-08-01",

--- a/resources/ausdigital-syn/2.0/samples/Invoice/SampleInvoice-Rule23-RCTIwithoutPayeeName.json
+++ b/resources/ausdigital-syn/2.0/samples/Invoice/SampleInvoice-Rule23-RCTIwithoutPayeeName.json
@@ -1,8 +1,9 @@
 {
     "Invoice": {
+        "documentIdentifier": "digitalbusinesscouncil.com.au::urn:oasis:names:specification:ubl:schema:xsd:Invoice-2::Invoice##UBL-2.1",
         "ublVersionID": "2.1",
-        "customizationID": "urn:resources.digitalbusinesscouncil.com.au:dbc:invoicing:documents:core invoice:xsd::core invoice 1##urn:resources.digitalbusinesscouncil.com.au:dbc:einvoicing:process:einvoicing02:ver1.0",
-        "profileID": "urn:resources.digitalbusinesscouncil.com.au:dbc:einvoicing:ver1.0",
+        "customizationID": "digitalbusinesscouncil.com.au",
+        "profileID": "rcti:v1.0",
         "id": "TOSL-108-A",
         "issueDate": "2016-07-01",
         "dueDate": "2016-08-01",

--- a/resources/ausdigital-syn/2.0/samples/Invoice/SampleInvoice-Rule32-PeriodEndDateBeforeStartDate.json
+++ b/resources/ausdigital-syn/2.0/samples/Invoice/SampleInvoice-Rule32-PeriodEndDateBeforeStartDate.json
@@ -1,8 +1,9 @@
 {
     "Invoice": {
+        "documentIdentifier": "digitalbusinesscouncil.com.au::urn:oasis:names:specification:ubl:schema:xsd:Invoice-2::Invoice##UBL-2.1",
         "ublVersionID": "2.1",
-        "customizationID": "urn:resources.digitalbusinesscouncil.com.au:dbc:invoicing:documents:core invoice:xsd::core invoice 1##urn:resources.digitalbusinesscouncil.com.au:dbc:einvoicing:process:einvoicing01:ver1.0",
-        "profileID": "urn:resources.digitalbusinesscouncil.com.au:dbc:einvoicing:ver1.0",
+        "customizationID": "digitalbusinesscouncil.com.au",
+        "profileID": "invoice:v1.0",
         "id": "TOSL-108-A",
         "issueDate": "2016-07-01",
         "dueDate": "2016-08-01",

--- a/resources/ausdigital-syn/2.0/samples/Invoice/SampleInvoice-Rule4-NoSupplierGSTIdentifier.json
+++ b/resources/ausdigital-syn/2.0/samples/Invoice/SampleInvoice-Rule4-NoSupplierGSTIdentifier.json
@@ -1,8 +1,9 @@
 {
     "Invoice": {
+        "documentIdentifier": "digitalbusinesscouncil.com.au::urn:oasis:names:specification:ubl:schema:xsd:Invoice-2::Invoice##UBL-2.1",
         "ublVersionID": "2.1",
-        "customizationID": "urn:resources.digitalbusinesscouncil.com.au:dbc:invoicing:documents:core invoice:xsd::core invoice 1##urn:resources.digitalbusinesscouncil.com.au:dbc:einvoicing:process:einvoicing01:ver1.0",
-        "profileID": "urn:resources.digitalbusinesscouncil.com.au:dbc:einvoicing:ver1.0",
+        "customizationID": "digitalbusinesscouncil.com.au",
+        "profileID": "invoice:v1.0",
         "id": "TOSL-108-A",
         "issueDate": "2016-07-01",
         "dueDate": "2016-08-01",

--- a/resources/ausdigital-syn/2.0/samples/Invoice/SampleInvoice-Rule47-NetAmountNotSumOfLineNetAmounts.json
+++ b/resources/ausdigital-syn/2.0/samples/Invoice/SampleInvoice-Rule47-NetAmountNotSumOfLineNetAmounts.json
@@ -1,8 +1,9 @@
 {
     "Invoice": {
+        "documentIdentifier": "digitalbusinesscouncil.com.au::urn:oasis:names:specification:ubl:schema:xsd:Invoice-2::Invoice##UBL-2.1",
         "ublVersionID": "2.1",
-        "customizationID": "urn:resources.digitalbusinesscouncil.com.au:dbc:invoicing:documents:core invoice:xsd::core invoice 1##urn:resources.digitalbusinesscouncil.com.au:dbc:einvoicing:process:einvoicing01:ver1.0",
-        "profileID": "urn:resources.digitalbusinesscouncil.com.au:dbc:einvoicing:ver1.0",
+        "customizationID": "digitalbusinesscouncil.com.au",
+        "profileID": "invoice:v1.0",
         "id": "TOSL-108-A",
         "issueDate": "2016-07-01",
         "dueDate": "2016-08-01",

--- a/resources/ausdigital-syn/2.0/samples/Invoice/SampleInvoice-Rule48-AllowanceAmountNotLineAllowances.json
+++ b/resources/ausdigital-syn/2.0/samples/Invoice/SampleInvoice-Rule48-AllowanceAmountNotLineAllowances.json
@@ -1,8 +1,9 @@
 {
     "Invoice": {
+        "documentIdentifier": "digitalbusinesscouncil.com.au::urn:oasis:names:specification:ubl:schema:xsd:Invoice-2::Invoice##UBL-2.1",
         "ublVersionID": "2.1",
-        "customizationID": "urn:resources.digitalbusinesscouncil.com.au:dbc:invoicing:documents:core invoice:xsd::core invoice 1##urn:resources.digitalbusinesscouncil.com.au:dbc:einvoicing:process:einvoicing01:ver1.0",
-        "profileID": "urn:resources.digitalbusinesscouncil.com.au:dbc:einvoicing:ver1.0",
+        "customizationID": "digitalbusinesscouncil.com.au",
+        "profileID": "invoice:v1.0",
         "id": "TOSL-108-A",
         "issueDate": "2016-07-01",
         "dueDate": "2016-08-01",

--- a/resources/ausdigital-syn/2.0/samples/Invoice/SampleInvoice-Rule52-TotalAmountNotNetPlusTax.json
+++ b/resources/ausdigital-syn/2.0/samples/Invoice/SampleInvoice-Rule52-TotalAmountNotNetPlusTax.json
@@ -1,8 +1,9 @@
 {
     "Invoice": {
+        "documentIdentifier": "digitalbusinesscouncil.com.au::urn:oasis:names:specification:ubl:schema:xsd:Invoice-2::Invoice##UBL-2.1",
         "ublVersionID": "2.1",
-        "customizationID": "urn:resources.digitalbusinesscouncil.com.au:dbc:invoicing:documents:core invoice:xsd::core invoice 1##urn:resources.digitalbusinesscouncil.com.au:dbc:einvoicing:process:einvoicing01:ver1.0",
-        "profileID": "urn:resources.digitalbusinesscouncil.com.au:dbc:einvoicing:ver1.0",
+        "customizationID": "digitalbusinesscouncil.com.au",
+        "profileID": "invoice:v1.0",
         "id": "TOSL-108-A",
         "issueDate": "2016-07-01",
         "dueDate": "2016-08-01",

--- a/resources/ausdigital-syn/2.0/samples/Invoice/SampleInvoice-Rule6-NoBuyersGSTIdentifier.json
+++ b/resources/ausdigital-syn/2.0/samples/Invoice/SampleInvoice-Rule6-NoBuyersGSTIdentifier.json
@@ -1,8 +1,9 @@
 {
     "Invoice": {
+        "documentIdentifier": "digitalbusinesscouncil.com.au::urn:oasis:names:specification:ubl:schema:xsd:Invoice-2::Invoice##UBL-2.1",
         "ublVersionID": "2.1",
-        "customizationID": "urn:resources.digitalbusinesscouncil.com.au:dbc:invoicing:documents:core invoice:xsd::core invoice 1##urn:resources.digitalbusinesscouncil.com.au:dbc:einvoicing:process:einvoicing01:ver1.0",
-        "profileID": "urn:resources.digitalbusinesscouncil.com.au:dbc:einvoicing:ver1.0",
+        "customizationID": "digitalbusinesscouncil.com.au",
+        "profileID": "invoice:v1.0",
         "id": "TOSL-108-A",
         "issueDate": "2016-07-01",
         "dueDate": "2016-08-01",

--- a/resources/ausdigital-syn/2.0/samples/Invoice/SampleInvoice-Rule60-InvoiceTotalNegative.json
+++ b/resources/ausdigital-syn/2.0/samples/Invoice/SampleInvoice-Rule60-InvoiceTotalNegative.json
@@ -1,8 +1,9 @@
 {
     "Invoice": {
+        "documentIdentifier": "digitalbusinesscouncil.com.au::urn:oasis:names:specification:ubl:schema:xsd:Invoice-2::Invoice##UBL-2.1",
         "ublVersionID": "2.1",
-        "customizationID": "urn:resources.digitalbusinesscouncil.com.au:dbc:invoicing:documents:core invoice:xsd::core invoice 1##urn:resources.digitalbusinesscouncil.com.au:dbc:einvoicing:process:einvoicing01:ver1.0",
-        "profileID": "urn:resources.digitalbusinesscouncil.com.au:dbc:einvoicing:ver1.0",
+        "customizationID": "digitalbusinesscouncil.com.au",
+        "profileID": "invoice:v1.0",
         "id": "TOSL-108-A",
         "issueDate": "2016-07-01",
         "dueDate": "2016-08-01",

--- a/resources/ausdigital-syn/2.0/samples/Invoice/SampleInvoice-Rule63-PriceIsNegative.json
+++ b/resources/ausdigital-syn/2.0/samples/Invoice/SampleInvoice-Rule63-PriceIsNegative.json
@@ -1,8 +1,9 @@
 {
     "Invoice": {
+        "documentIdentifier": "digitalbusinesscouncil.com.au::urn:oasis:names:specification:ubl:schema:xsd:Invoice-2::Invoice##UBL-2.1",
         "ublVersionID": "2.1",
-        "customizationID": "urn:resources.digitalbusinesscouncil.com.au:dbc:invoicing:documents:core invoice:xsd::core invoice 1##urn:resources.digitalbusinesscouncil.com.au:dbc:einvoicing:process:einvoicing01:ver1.0",
-        "profileID": "urn:resources.digitalbusinesscouncil.com.au:dbc:einvoicing:ver1.0",
+        "customizationID": "digitalbusinesscouncil.com.au",
+        "profileID": "invoice:v1.0",
         "id": "TOSL-108-A",
         "issueDate": "2016-07-01",
         "dueDate": "2016-08-01",

--- a/resources/ausdigital-syn/2.0/samples/Invoice/SampleInvoice-Rule67-NoAllowanceAmount.json
+++ b/resources/ausdigital-syn/2.0/samples/Invoice/SampleInvoice-Rule67-NoAllowanceAmount.json
@@ -1,8 +1,9 @@
 {
     "Invoice": {
+        "documentIdentifier": "digitalbusinesscouncil.com.au::urn:oasis:names:specification:ubl:schema:xsd:Invoice-2::Invoice##UBL-2.1",
         "ublVersionID": "2.1",
-        "customizationID": "urn:resources.digitalbusinesscouncil.com.au:dbc:invoicing:documents:core invoice:xsd::core invoice 1##urn:resources.digitalbusinesscouncil.com.au:dbc:einvoicing:process:einvoicing01:ver1.0",
-        "profileID": "urn:resources.digitalbusinesscouncil.com.au:dbc:einvoicing:ver1.0",
+        "customizationID": "digitalbusinesscouncil.com.au",
+        "profileID": "invoice:v1.0",
         "id": "TOSL-108-A",
         "issueDate": "2016-07-01",
         "dueDate": "2016-08-01",

--- a/resources/ausdigital-syn/2.0/samples/Invoice/SampleInvoice-Rule72-NoChargeAmount.json
+++ b/resources/ausdigital-syn/2.0/samples/Invoice/SampleInvoice-Rule72-NoChargeAmount.json
@@ -1,8 +1,9 @@
 {
     "Invoice": {
+        "documentIdentifier": "digitalbusinesscouncil.com.au::urn:oasis:names:specification:ubl:schema:xsd:Invoice-2::Invoice##UBL-2.1",
         "ublVersionID": "2.1",
-        "customizationID": "urn:resources.digitalbusinesscouncil.com.au:dbc:invoicing:documents:core invoice:xsd::core invoice 1##urn:resources.digitalbusinesscouncil.com.au:dbc:einvoicing:process:einvoicing01:ver1.0",
-        "profileID": "urn:resources.digitalbusinesscouncil.com.au:dbc:einvoicing:ver1.0",
+        "customizationID": "digitalbusinesscouncil.com.au",
+        "profileID": "invoice:v1.0",
         "id": "TOSL-108-A",
         "issueDate": "2016-07-01",
         "dueDate": "2016-08-01",

--- a/resources/ausdigital-syn/2.0/samples/Invoice/SampleInvoice-Rule77-InvoiceLineAllowanceAmount.json
+++ b/resources/ausdigital-syn/2.0/samples/Invoice/SampleInvoice-Rule77-InvoiceLineAllowanceAmount.json
@@ -1,8 +1,9 @@
 {
     "Invoice": {
+        "documentIdentifier": "digitalbusinesscouncil.com.au::urn:oasis:names:specification:ubl:schema:xsd:Invoice-2::Invoice##UBL-2.1",
         "ublVersionID": "2.1",
-        "customizationID": "urn:resources.digitalbusinesscouncil.com.au:dbc:invoicing:documents:core invoice:xsd::core invoice 1##urn:resources.digitalbusinesscouncil.com.au:dbc:einvoicing:process:einvoicing01:ver1.0",
-        "profileID": "urn:resources.digitalbusinesscouncil.com.au:dbc:einvoicing:ver1.0",
+        "customizationID": "digitalbusinesscouncil.com.au",
+        "profileID": "invoice:v1.0",
         "id": "TOSL-108-A",
         "issueDate": "2016-07-01",
         "dueDate": "2016-08-01",

--- a/resources/ausdigital-syn/2.0/samples/Invoice/SampleInvoice-Rule78-InvoiceLineAllowanceDescription.json
+++ b/resources/ausdigital-syn/2.0/samples/Invoice/SampleInvoice-Rule78-InvoiceLineAllowanceDescription.json
@@ -1,8 +1,9 @@
 {
     "Invoice": {
+        "documentIdentifier": "digitalbusinesscouncil.com.au::urn:oasis:names:specification:ubl:schema:xsd:Invoice-2::Invoice##UBL-2.1",
         "ublVersionID": "2.1",
-        "customizationID": "urn:resources.digitalbusinesscouncil.com.au:dbc:invoicing:documents:core invoice:xsd::core invoice 1##urn:resources.digitalbusinesscouncil.com.au:dbc:einvoicing:process:einvoicing01:ver1.0",
-        "profileID": "urn:resources.digitalbusinesscouncil.com.au:dbc:einvoicing:ver1.0",
+        "customizationID": "digitalbusinesscouncil.com.au",
+        "profileID": "invoice:v1.0",
         "id": "TOSL-108-A",
         "issueDate": "2016-07-01",
         "dueDate": "2016-08-01",

--- a/resources/ausdigital-syn/2.0/samples/Invoice/SampleInvoice-Rule8-NoInvoiceLinedescription.json
+++ b/resources/ausdigital-syn/2.0/samples/Invoice/SampleInvoice-Rule8-NoInvoiceLinedescription.json
@@ -1,8 +1,9 @@
 {
     "Invoice": {
+        "documentIdentifier": "digitalbusinesscouncil.com.au::urn:oasis:names:specification:ubl:schema:xsd:Invoice-2::Invoice##UBL-2.1",
         "ublVersionID": "2.1",
-        "customizationID": "urn:resources.digitalbusinesscouncil.com.au:dbc:invoicing:documents:core invoice:xsd::core invoice 1##urn:resources.digitalbusinesscouncil.com.au:dbc:einvoicing:process:einvoicing01:ver1.0",
-        "profileID": "urn:resources.digitalbusinesscouncil.com.au:dbc:einvoicing:ver1.0",
+        "customizationID": "digitalbusinesscouncil.com.au",
+        "profileID": "invoice:v1.0",
         "id": "TOSL-108-A",
         "issueDate": "2016-07-01",
         "dueDate": "2016-08-01",

--- a/resources/ausdigital-syn/2.0/samples/Invoice/SampleInvoice-Rule81-InvoiceLineChargeAmount.json
+++ b/resources/ausdigital-syn/2.0/samples/Invoice/SampleInvoice-Rule81-InvoiceLineChargeAmount.json
@@ -1,8 +1,9 @@
 {
     "Invoice": {
+        "documentIdentifier": "digitalbusinesscouncil.com.au::urn:oasis:names:specification:ubl:schema:xsd:Invoice-2::Invoice##UBL-2.1",
         "ublVersionID": "2.1",
-        "customizationID": "urn:resources.digitalbusinesscouncil.com.au:dbc:invoicing:documents:core invoice:xsd::core invoice 1##urn:resources.digitalbusinesscouncil.com.au:dbc:einvoicing:process:einvoicing01:ver1.0",
-        "profileID": "urn:resources.digitalbusinesscouncil.com.au:dbc:einvoicing:ver1.0",
+        "customizationID": "digitalbusinesscouncil.com.au",
+        "profileID": "invoice:v1.0",
         "id": "TOSL-108-A",
         "issueDate": "2016-07-01",
         "dueDate": "2016-08-01",

--- a/resources/ausdigital-syn/2.0/samples/Invoice/SampleInvoice-Rule82-InvoiceLineChargeReason.json
+++ b/resources/ausdigital-syn/2.0/samples/Invoice/SampleInvoice-Rule82-InvoiceLineChargeReason.json
@@ -1,8 +1,9 @@
 {
     "Invoice": {
+        "documentIdentifier": "digitalbusinesscouncil.com.au::urn:oasis:names:specification:ubl:schema:xsd:Invoice-2::Invoice##UBL-2.1",
         "ublVersionID": "2.1",
-        "customizationID": "urn:resources.digitalbusinesscouncil.com.au:dbc:invoicing:documents:core invoice:xsd::core invoice 1##urn:resources.digitalbusinesscouncil.com.au:dbc:einvoicing:process:einvoicing01:ver1.0",
-        "profileID": "urn:resources.digitalbusinesscouncil.com.au:dbc:einvoicing:ver1.0",
+        "customizationID": "digitalbusinesscouncil.com.au",
+        "profileID": "invoice:v1.0",
         "id": "TOSL-108-A",
         "issueDate": "2016-07-01",
         "dueDate": "2016-08-01",

--- a/resources/ausdigital-syn/2.0/samples/Invoice/SampleInvoice-Rule89-NoFinancialAccountForCredit.json
+++ b/resources/ausdigital-syn/2.0/samples/Invoice/SampleInvoice-Rule89-NoFinancialAccountForCredit.json
@@ -1,8 +1,9 @@
 {
     "Invoice": {
+        "documentIdentifier": "digitalbusinesscouncil.com.au::urn:oasis:names:specification:ubl:schema:xsd:Invoice-2::Invoice##UBL-2.1",
         "ublVersionID": "2.1",
-        "customizationID": "urn:resources.digitalbusinesscouncil.com.au:dbc:invoicing:documents:core invoice:xsd::core invoice 1##urn:resources.digitalbusinesscouncil.com.au:dbc:einvoicing:process:einvoicing01:ver1.0",
-        "profileID": "urn:resources.digitalbusinesscouncil.com.au:dbc:einvoicing:ver1.0",
+        "customizationID": "digitalbusinesscouncil.com.au",
+        "profileID": "invoice:v1.0",
         "id": "TOSL-108-A",
         "issueDate": "2016-07-01",
         "dueDate": "2016-08-01",

--- a/resources/ausdigital-syn/2.0/samples/Invoice/SampleInvoice-Rule90-InvalidPaymentMeansCode.json
+++ b/resources/ausdigital-syn/2.0/samples/Invoice/SampleInvoice-Rule90-InvalidPaymentMeansCode.json
@@ -1,8 +1,9 @@
 {
     "Invoice": {
+        "documentIdentifier": "digitalbusinesscouncil.com.au::urn:oasis:names:specification:ubl:schema:xsd:Invoice-2::Invoice##UBL-2.1",
         "ublVersionID": "2.1",
-        "customizationID": "urn:resources.digitalbusinesscouncil.com.au:dbc:invoicing:documents:core invoice:xsd::core invoice 1##urn:resources.digitalbusinesscouncil.com.au:dbc:einvoicing:process:einvoicing01:ver1.0",
-        "profileID": "urn:resources.digitalbusinesscouncil.com.au:dbc:einvoicing:ver1.0",
+        "customizationID": "digitalbusinesscouncil.com.au",
+        "profileID": "invoice:v1.0",
         "id": "TOSL-108-A",
         "issueDate": "2016-07-01",
         "dueDate": "2016-08-01",

--- a/resources/ausdigital-syn/2.0/samples/Invoice/SampleInvoice-Rule91-NoFinancialInstitutionID.json
+++ b/resources/ausdigital-syn/2.0/samples/Invoice/SampleInvoice-Rule91-NoFinancialInstitutionID.json
@@ -1,8 +1,9 @@
 {
     "Invoice": {
+        "documentIdentifier": "digitalbusinesscouncil.com.au::urn:oasis:names:specification:ubl:schema:xsd:Invoice-2::Invoice##UBL-2.1",
         "ublVersionID": "2.1",
-        "customizationID": "urn:resources.digitalbusinesscouncil.com.au:dbc:invoicing:documents:core invoice:xsd::core invoice 1##urn:resources.digitalbusinesscouncil.com.au:dbc:einvoicing:process:einvoicing01:ver1.0",
-        "profileID": "urn:resources.digitalbusinesscouncil.com.au:dbc:einvoicing:ver1.0",
+        "customizationID": "digitalbusinesscouncil.com.au",
+        "profileID": "invoice:v1.0",
         "id": "TOSL-108-A",
         "issueDate": "2016-07-01",
         "dueDate": "2016-08-01",


### PR DESCRIPTION
"documentIdentifier" has been added, it reflects DCP documentIdentifier.
According to (OASIS SMP specification)[http://docs.oasis-open.org/bdxr/bdx-smp/v1.0/csprd01/bdx-smp-v1.0-csprd01.html] the format is the following:
`{identifier scheme}::{id} `
where id:
`{identifier scheme}::{rootNamespace}::{documentElementLocalName}[##{Subtype identifier}]`
In other words, UBL JSON attribute "documentIdentifier" value equals to DCP documentIdentifier URL representation:
`"digitalbusinesscouncil.com.au::urn:oasis:names:specification:ubl:schema:xsd:Invoice-2::Invoice##UBL-2.1"`

According to [UBL2-Customization1.0cs01.pdf](http://docs.oasis-open.org/ubl/guidelines/UBL2-Customization1.0cs01.pdf):
```
1.4.6 Identifying versions, customizations, and profiles 
A document instance claiming to satisfy the constraints for a particular profile in a customization
asserts this using the following information entities at the root of each document:
• UBLVersionID
An identifier reserved for UBL version identification. Not actually a modifiable value, but
required to understand which version of UBL is being customized.
• UBLCustomizationID
An identifier (such as a URI) for a user-defined customization of UBL.
• UBLProfileID
An identifier (such as a URI) for a user-defined profile of the customization being used.
Profiles are further refinements of customizations that enable “families” of customizations
to be implemented.
For example, Stand Alone Invoicing, which is a profile of the Northern European Subset
customization of the UBL 2.0 standard, is identified as:
• UBLVersionID: 2.0
• UBLCustomizationID: NES
• UBLProfileID: urn:www:nesubl:eu:profiles:profile1:ver1.0 
```
In case of AusDigital for Tax Invoice Profile:
```
• UBLVersionID: 2.1
• UBLCustomizationID: digitalbusinesscouncil.com.au
• UBLProfileID: credit-note:v1.0
```

ProcessIdentifier is described in the SMP specification as following:

> A process is identified by a string that is defined outside of this specification. For example, the CEN workshop on Business Interoperability Interfaces (BII) has chosen to indicate a UBL-based ”simple procurement” process (or ”profile” in UBL terminology) with the identifier “BII07”, and a UBL-based basic invoice exchange profile with the identifier “BII04”.

AusDigital defines ProcessIdentifier as following:
`{customizationID}::{ProfileID}`
where {ProfileID}:
`{processContext:vX.Y}`
processContext is one of the Invoice Document Types:

1. invoice
2. adjustment
3. rcti
4. taxreceipt
5. debitnote
6. creditnote

So we have a mapping between SMP documentIdentifier/processIdentifier and UBL root namespace/customisation/customisation profile:
{SMP documentIdentifier} == {UBL documentIdentifier}
{SMP processIdentifier} == {UBL customizationID}::{UBL profileID}

DocumentIdentifier examples:

  Source | identifier scheme | rootNamespace | documentElementLocalName | Subtype identifier 
--- | --- | --- | --- | ---
SMP | bdx-docid-qns | urn:oasis:names:specification:ubl:schema:xsd:Order-2 | Order | UBL-2.0
DBC | dbc | urn:www.digitalbusinesscouncil.com.au:dbc:einvoicing:doctype:core-invoice:xsd | core-invoice-1 | urn:www.digitalbusinesscouncil.com.au:dbc:einvoicing:process:einvoicing01:ver1.0
AusDigital | digitalbusinesscouncil.com.au | urn:oasis:names:specification:ubl:schema:xsd:Invoice-2 | Invoice | UBL-2.1

ProcessIdentifier examples:

  Source | identifier scheme | ProcessIdentifier 
--- | --- | ---
SMP | cenbii-procid-ubl | BII04
DBC | dbc-procid | urn:www.digitalbusinesscouncil.com.au:dbc:einvoicing:ver1.0
AusDigital | digitalbusinesscouncil.com.au | credit-note:v1.0
